### PR TITLE
Strip unknown tags

### DIFF
--- a/libraries/lambda_handlers/uw_v2_catalog_handler.py
+++ b/libraries/lambda_handlers/uw_v2_catalog_handler.py
@@ -20,7 +20,7 @@ from libraries.tools.dict_utils import merge_dict
 from libraries.tools.file_utils import write_file, read_file
 from libraries.tools.legacy_utils import index_obs
 from libraries.tools.url_utils import download_file, get_url
-from libraries.tools.usfm_utils import strip_word_data, convert_chunk_markers
+from libraries.tools.usfm_utils import strip_word_data, convert_chunk_markers, remove_unknown_markers
 
 from libraries.tools.signer import Signer, ENC_PRIV_PEM_PATH
 from libraries.lambda_handlers.instance_handler import InstanceHandler
@@ -400,7 +400,7 @@ class UwV2CatalogHandler(InstanceHandler):
         usfm_file = os.path.join(self.temp_dir, md5(url).hexdigest())
         self.download_file(url, usfm_file)
         usfm = read_file(usfm_file)
-        return convert_chunk_markers(strip_word_data(usfm))
+        return remove_unknown_markers(convert_chunk_markers(strip_word_data(usfm)))
 
 
     def _get_status(self):

--- a/libraries/tools/ts_v2_utils.py
+++ b/libraries/tools/ts_v2_utils.py
@@ -16,7 +16,7 @@ from libraries.lambda_handlers.handler import Handler
 from libraries.tools.file_utils import read_file, write_file
 from libraries.tools.url_utils import get_url
 from usfm_tools.transform import UsfmTransform
-from libraries.tools.usfm_utils import convert_chunk_markers, strip_word_data
+from libraries.tools.usfm_utils import convert_chunk_markers, strip_word_data, remove_unknown_markers
 
 def download_chunks(pid, dest):
     """
@@ -185,7 +185,7 @@ def build_usx(usfm_dir, usx_dir):
     for name in files:
         f = os.path.join(usfm_dir, name)
         usfm = read_file(f)
-        write_file(f, convert_chunk_markers(strip_word_data(usfm)))
+        write_file(f, remove_unknown_markers(convert_chunk_markers(strip_word_data(usfm))))
 
     UsfmTransform.buildUSX(usfm_dir, usx_dir, '', True)
 

--- a/libraries/tools/usfm_utils.py
+++ b/libraries/tools/usfm_utils.py
@@ -335,6 +335,14 @@ def convert_chunk_markers(str):
     """
     return re.sub(r'\\ts\b', '\\s5', str)
 
+def remove_unknown_markers(str):
+    """
+    Removes tags unknown to our version of usfm-tools
+    :param str:
+    :return: the converted string
+    """
+    return re.sub(r'(\\)(\+?)(pn)(\*?)\b', '', str)
+
 def usfm3_to_usfm2(usfm3):
     """
     Converts a USFM 3 string to a USFM 2 compatible string

--- a/libraries/tools/usfm_utils.py
+++ b/libraries/tools/usfm_utils.py
@@ -341,7 +341,11 @@ def remove_unknown_markers(str):
     :param str:
     :return: the converted string
     """
-    return re.sub(r'(\\)(\+?)(pn)(\*?)\b', '', str)
+    opening_slash_and_plus = r'(\\)(\+?)'
+    tags = r'(pn|fv)'
+    splat_and_boundary = r'(\*?)\b'
+    pattern = opening_slash_and_plus + tags + splat_and_boundary
+    return re.sub(pattern, '', str)
 
 def usfm3_to_usfm2(usfm3):
     """


### PR DESCRIPTION
The [usfm_tools library](https://pypi.org/project/usfm-tools/0.0.13/) doesn't support certain tags, and the pipeline dies when it encounters them.

The library _could_ be forked and updated, but probably shouldn't be before the whole pipeline system is updated to Python 3 (because usfm_tools has already gone to P3 and forking the old P2 version would make porting harder in the future).

Instead, this PR ignores the unsupported tags. Currently, only two tags are troublesome and ignored, [\fv (footnote multi-verse quote)](https://ubsicap.github.io/usfm/notes_basic/fnotes.html#fv-fv) and [\pn (proper name)](https://ubsicap.github.io/usfm/characters/index.html#pn-pn), which have minimal impact on the catalog.