### PR TITLE
Increase ram

### DIFF
--- a/project.develop.json
+++ b/project.develop.json
@@ -2,7 +2,7 @@
   "name": "dev-d43-catalog",
   "description": "Development Lambda functions for handling the Door43 Catalog",
   "runtime": "python2.7",
-  "memory": 512,
+  "memory": 1024,
   "timeout": 300,
   "role": "arn:aws:iam::581647696645:role/tx_lambda_function",
   "environment": {

--- a/project.json
+++ b/project.json
@@ -2,7 +2,7 @@
   "name": "dev-d43-catalog",
   "description": "Development Lambda functions for handling the Door43 Catalog",
   "runtime": "python2.7",
-  "memory": 512,
+  "memory": 1024,
   "timeout": 300,
   "role": "arn:aws:iam::002723143144:role/tx_lambda_function",
   "environment": {},

--- a/project.poc.json
+++ b/project.poc.json
@@ -2,7 +2,7 @@
   "name": "poc-d43-catalog",
   "description": "Development Lambda functions for handling the Door43 Catalog",
   "runtime": "python2.7",
-  "memory": 512,
+  "memory": 1024,
   "timeout": 300,
   "role": "arn:aws:iam::581647696645:role/tx_lambda_function",
   "environment": {},

--- a/project.prod.json
+++ b/project.prod.json
@@ -2,7 +2,7 @@
   "name": "d43-catalog",
   "description": "Lambda functions for handling the Door43 Catalog",
   "runtime": "python2.7",
-  "memory": 512,
+  "memory": 1024,
   "timeout": 300,
   "role": "arn:aws:iam::581647696645:role/tx_lambda_function",
   "environment": {


### PR DESCRIPTION
Pypy is more memory hungry and is getting close to the previous limit of 512MB during pipeline runs. Increasing to 1GB for future safety.