### PR TITLE
Log handler

### DIFF
--- a/libraries/lambda_handlers/handler.py
+++ b/libraries/lambda_handlers/handler.py
@@ -35,6 +35,8 @@ class Handler(object):
         # Set up logger
         self.logger = logging.getLogger() # type: logging._loggerClass
         self.logger.setLevel(logging.DEBUG)
+        self.logger.addHandler(logging.StreamHandler())
+
         self.event = event
         self.context = context
 

--- a/libraries/lambda_handlers/ts_v2_catalog_handler.py
+++ b/libraries/lambda_handlers/ts_v2_catalog_handler.py
@@ -51,7 +51,8 @@ class TsV2CatalogHandler(InstanceHandler):
             self.db_handler = kwargs['dynamodb_handler']
         else:
             self.db_handler = DynamoDBHandler(self.status_db) # pragma: no cover
-
+            if self.db_handler.logger:
+                self.db_handler.logger.setLevel(logger.level)
         if 'url_handler' in kwargs:
             self.get_url = kwargs['url_handler']
         else:

--- a/libraries/lambda_handlers/ts_v2_catalog_handler.py
+++ b/libraries/lambda_handlers/ts_v2_catalog_handler.py
@@ -626,9 +626,10 @@ class TsV2CatalogHandler(InstanceHandler):
         :param upload:
         :return:
         """
-        self.cdn_handler.upload_file(upload['path'],
-                                     '{}/{}'.format(TsV2CatalogHandler.cdn_root_path,
-                                                    upload['key']))
+        path = upload['path']
+        key = '{}/{}'.format(TsV2CatalogHandler.cdn_root_path, upload['key'])
+        self.logger.debug('Uploading {}/{}'.format(path, key))
+        self.cdn_handler.upload_file(path, key)
 
     def _add_supplement(self, catalog, language, resource, project, modified, rc_type):
         """


### PR DESCRIPTION
Add a handler to send logs to the console, so they appear in CloudWatch. This may have been the default under AWS Python, but needs to be explicit for Pypy.

This PR also adds a logging statement for uploads to s3.