### PR TITLE
Pin attrs library to old version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+attrs==19.1.0
 mutagen==1.38
 coveralls==1.1
 markdown==2.6.8


### PR DESCRIPTION
This PR works around errors like the following in the "fork" Lambda function:
```
module initialization error: attrib() got an unexpected keyword argument 'convert'
```