### PR TITLE
Use unicode in link formatting

### DIFF
--- a/libraries/lambda_handlers/ts_v2_catalog_handler.py
+++ b/libraries/lambda_handlers/ts_v2_catalog_handler.py
@@ -531,7 +531,7 @@ class TsV2CatalogHandler(InstanceHandler):
                         # TRICKY: we converted the ta urls, but now we need to format them as dokuwiki links
                         # e.g. [[en:ta:vol1:translate:translate_unknown | How to Translate Unknowns]]
                         for ta_link in ta_html_re.findall(word_content):
-                            new_link = '[[{} | {}]]'.format(ta_link[1], ta_link[2])
+                            new_link = u'[[{} | {}]]'.format(ta_link[1], ta_link[2])
                             word_content = word_content.replace(ta_link[0], new_link)
 
                         words.append({

--- a/libraries/tools/ts_v2_utils.py
+++ b/libraries/tools/ts_v2_utils.py
@@ -402,7 +402,7 @@ def convert_rc_links(content, logger=None):
                     logger.warning(
                         'volume not found for {} while parsing link {}. Defaulting to vol1'.format(module, link[0]))
                 vol = 'vol1'
-            new_link = ':{}:{}:{}:{}:{}'.format(lid, rid, vol, pid, module)
+            new_link = u':{}:{}:{}:{}:{}'.format(lid, rid, vol, pid, module)
         if rid == 'ulb':
             pass
         if rid == 'udb':


### PR DESCRIPTION
This corrects errors like the following:
```
EnvironmentError: Bad Request: 'ascii' codec can't encode character u'\u0905' in position 0: ordinal not in range(128)
```